### PR TITLE
remove useless exception if no dbname

### DIFF
--- a/src/Driver.php
+++ b/src/Driver.php
@@ -52,10 +52,6 @@ class Driver implements \Doctrine\DBAL\Driver
             throw new ClickHouseException('Connection parameter `port` is required');
         }
 
-        if (! isset($params['dbname'])) {
-            throw new ClickHouseException('Connection parameter `dbname` is required');
-        }
-
         return new ClickHouseConnection($params, (string) $username, (string) $password, $this->getDatabasePlatform());
     }
 


### PR DESCRIPTION
In Doctrine bundle, class CreateDatabaseDoctrineCommand L95:

https://github.com/doctrine/DoctrineBundle/blob/2.7.x/Command/CreateDatabaseDoctrineCommand.php#L95


```
        // Need to get rid of _every_ occurrence of dbname from connection configuration and we have already extracted all relevant info from url
        unset($params['dbname'], $params['path'], $params['url']);
``` 
 
 Param dbname is removed 